### PR TITLE
Fixed grammar in handler/advise.js and info.js

### DIFF
--- a/src/handlers/advise.js
+++ b/src/handlers/advise.js
@@ -40,7 +40,7 @@ const handler = async (message, args) => {
 
     response += '\n\n_This data is updated every 30 seconds_';
 
-    message.channel.send(`<@${message.author.id}> I've sent you advise in your channel`);
+    message.channel.send(`<@${message.author.id}> I've sent you advice in your channel`);
 
     channel.send(`<@${message.author.id}>\n` + response);
 }

--- a/src/handlers/info.js
+++ b/src/handlers/info.js
@@ -32,5 +32,5 @@ export const AdvancedHelp = (message) => {
 }
 
 export const AdvancedPublicHelp  = (message) => {
-    return message.channel.send(`<@${message.author.id}> Public Repo Commands Help\n\n\`info\` Get info of script. Params <?script_name>\n\n\`export\` returns the parsed AST output returned by the parser [you're probably never gonna use this]. Params: <script_name>\n\n\`source\` Get the source code for a script. Params: <script_name>\n\nRunning public commands: !bz advanced <public_script_name>`);
+    return message.channel.send(`<@${message.author.id}> Public Repo Commands Help\n\n\`info\` Get info of script. Params <script_name>\n\n\`export\` returns the parsed AST output returned by the parser [you're probably never gonna use this]. Params: <script_name>\n\n\`source\` Get the source code for a script. Params: <script_name>\n\nRunning public commands: !bz advanced <public_script_name>`);
 }


### PR DESCRIPTION
Fixed sentence to say "I've sent you advice in your channel" and removed question mark in info.js which I assume was a typo.